### PR TITLE
Use single rendering script for all variations

### DIFF
--- a/src/Mint-Y/render-assets.sh
+++ b/src/Mint-Y/render-assets.sh
@@ -1,0 +1,64 @@
+#! /bin/bash
+
+INKSCAPE="/usr/bin/inkscape"
+OPTIPNG="/usr/bin/optipng"
+
+INDEX="assets.txt"
+if [[ $1 != "-dark" ]]; then
+    SRC_FILE="assets.svg"
+    ASSETS_DIR="assets"
+else
+    SRC_FILE="assets"$1".svg"
+    ASSETS_DIR="assets"$1
+fi
+mkdir -p $ASSETS_DIR
+
+render()
+{
+    echo Rendering $1
+    if [[ "$1" == *"@2"* ]]; then
+        $INKSCAPE --export-id=$2 --export-dpi=192 \
+                "${INKSCAPE_OPTS[@]}" $1 $SRC_FILE >/dev/null 2>&1 \
+        && $OPTIPNG -o7 --quiet $1
+    else
+        $INKSCAPE --export-id=$2 "${INKSCAPE_OPTS[@]}" $1 $SRC_FILE >/dev/null 2>&1 \
+        && $OPTIPNG -o7 --quiet $1
+    fi
+}
+
+# Set options for Inkscape depending on version.
+INKSCAPE_OPTS=( --export-id-only )
+case $($INKSCAPE -V | cut -d' ' -f2) in
+    # NB: The export option (-e or -o) must be the last option in the INKSCAPE_OPTS array.
+    0.*) INKSCAPE_OPTS+=('-z' '-e');; # -z specifies not to launch GUI, -e is export
+    1.*) INKSCAPE_OPTS+=('-o');;      # v1.0+ uses no GUI by default, -e replaced by -o
+esac
+
+for i in `cat $INDEX`
+do
+    if [ -f $ASSETS_DIR/$i.png ]; then
+        echo $ASSETS_DIR/$i.png exists.
+    else
+        render $ASSETS_DIR/$i.png $i &
+        # allow only to execute number of jobs in parallel
+        # equal to number of processors
+        if [[ $(jobs -r -p | wc -l) -gt $(nproc) ]]; then
+        # wait only for first job
+        wait $(jobs -p)
+        fi
+    fi
+    if [[ $1 == "s2" ]]; then
+        if [ -f $ASSETS_DIR/$i@2.png ]; then
+            echo $ASSETS_DIR/$i@2.png exists.
+        else
+            render $ASSETS_DIR/$i@2.png $i &
+            # allow only to execute number of jobs in parallel
+            # equal to number of processors
+            if [[ $(jobs -r -p | wc -l) -gt $(nproc) ]]; then
+            # wait only for first job
+            wait $(jobs -p)
+            fi
+        fi
+    fi
+done
+exit 0

--- a/update-variations.py
+++ b/update-variations.py
@@ -18,8 +18,9 @@ def usage ():
     sys.exit(1)
 
 def update_color (color):
-    variation = "src/Mint-Y/variations/%s" % color
-    print("updating %s" % variation)
+    variation = curdir+"/src/Mint-Y/variations/%s" % color
+    rendering_script = curdir+"/src/Mint-Y/render-assets.sh"
+    print("updating %s" % color)
     os.system("rm -rf %s" % variation)
     os.system("mkdir -p %s/gtk-2.0" % variation)
     os.system("mkdir -p %s/gtk-3.0" % variation)
@@ -38,14 +39,9 @@ def update_color (color):
     files.append("gtk-2.0/assets")
     files.append("gtk-2.0/assets-dark")
     files.append("gtk-2.0/assets.txt")
-    files.append("gtk-2.0/render-assets.sh")
-    files.append("gtk-2.0/render-dark-assets.sh")
     files.append("gtk-3.0/assets")
     files.append("gtk-3.0/assets.txt")
-    files.append("gtk-3.0/render-assets.sh")
-    files.append("xfwm4/render-assets.sh")
     files.append("xfwm4/assets.txt")
-    files.append("xfwm4-dark/render-assets.sh")
     files.append("xfwm4-dark/assets.txt")
 
     for file in files:
@@ -66,21 +62,38 @@ def update_color (color):
             os.system("sed -i s'/%(accent)s/%(color_accent)s/gI' %(file)s" % {'accent': accent, 'color_accent': y_hex_colors4[color], 'file': asset_path})
 
     # Render assets
+    # TODO: need better idea to do '-dark'
+    # and '@2' arguments
     os.chdir(variation)
-    os.chdir("gtk-2.0")
+    os.chdir(variation+"/gtk-2.0")
+    print("**Rendering gtk-2.0 assets...")
     os.system("rm -rf assets/*")
+    os.system(rendering_script)
+
+    print("**Rendering gtk-2.0 dark assets...")
     os.system("rm -rf assets-dark/*")
-    os.system("./render-assets.sh")
-    os.system("./render-dark-assets.sh")
-    os.chdir("../gtk-3.0/")
+    os.system(rendering_script+" -dark")
+    # os.system("rm -rf assets/*@2.png")
+
+    print("**Rendering gtk-3.0 assets...")
+    os.chdir(variation+"/gtk-3.0/")
     os.system("rm -rf assets/*")
-    os.system("./render-assets.sh")
-    os.chdir("../xfwm4/")
+    os.system(rendering_script+" s2")
+
+    print("**Rendering xfwm4 assets...")
+    os.chdir(variation+"/xfwm4/")
     os.system("rm -rf *.png")
-    os.system("./render-assets.sh")
-    os.chdir("../xfwm4-dark/")
+    os.system(rendering_script)
+    # os.system("rm -rf assets/*@2.png")
+    os.system("mv assets/*.png ./ && rm -rf assets/")
+
+    print("**Rendering xfwm4 dark assets...")
+    os.chdir(variation+"/xfwm4-dark/")
     os.system("rm -rf *.png")
-    os.system("./render-assets.sh")
+    os.system(rendering_script)
+    # os.system("rm -rf assets/*@2.png")
+    os.system("mv assets/*.png ./ && rm -rf assets/")
+    print("")
     os.chdir(curdir)
 
 if len(sys.argv) < 2:


### PR DESCRIPTION
- uses single render-assets.sh for all variations
- single rendering script takes care of all assets
  used in gtk variations and xfwm variations
- reduces repo size and better automation
- No need to include .png files with repo as
  they can be generated during building deb packaging
- better rendering of assets for new themes like gtk-4.0
- original rendering scripts has been kept back but can be removed