### PR TITLE
Fix Theme parsing error

### DIFF
--- a/src/Mint-Y/gtk-3.0/sass/tweak-apps/_tweak-drawing.scss
+++ b/src/Mint-Y/gtk-3.0/sass/tweak-apps/_tweak-drawing.scss
@@ -130,6 +130,6 @@ $container_padding: 2px;
   //
   // reset
   //
-    color: none;
+    color: transparent;
   }
 }


### PR DESCRIPTION
GTK apps are throwing error 'none' is not a valid color name. Use 'transparent' instead of none.